### PR TITLE
Add webhook exposure endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,9 @@ import shapehandler
 import slicerhandler
 import point_calc as pc
 
-from telegram_bot.handlers import send_message_to_telegram, fetch_file, get_openai_response, download_file, analyze_image_with_openai
+from telegram_bot.handlers import send_message_to_telegram, fetch_file, get_openai_response, download_file, analyze_image_with_openai, TELEGRAM_API_URL
+from pyngrok import ngrok
+import requests
 import telegram_bot.parametershandler
 welcome_mesage = "Hello and welcome! This isn’t just a chatbot. It’s a guide through an invisible landscape—one that shifts with every thought you share. As we talk, a living shape grows from our conversation.Type anything to begin the journey."
 port = 'COM3' # use this port for Windows
@@ -116,6 +118,19 @@ def hello():
         'layer_hight': slicer_handler.params['layer_hight'],
         'update_rate': update_rate
     })
+
+@socketio.on('expose_webhook')
+def expose_webhook():
+    """Expose Flask server via ngrok and send URL to client."""
+    try:
+        public_url = ngrok.connect(5000).public_url
+        emit('webhook_url', {'url': public_url})
+        try:
+            requests.get(f"{TELEGRAM_API_URL}/setWebhook", params={'url': public_url})
+        except Exception as e:
+            print(f"Failed to set Telegram webhook: {e}")
+    except Exception as e:
+        print(f"ngrok error: {e}")
 
 @socketio.on('slicer_options')
 def slicer_options(data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -176,3 +176,4 @@ torchvision==0.17.1
 typing_extensions==4.10.0
 Werkzeug==2.0.0
 wsproto==1.2.0
+pyngrok==6.1.0

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -41,6 +41,9 @@ socket.on('update_current_shape', (data) => {
 socket.on('line_preview', (data) => {
     vm.line_displacement = data["line_displacement"]
 });
+socket.on('webhook_url', (data) => {
+    vm.webhookUrl = data.url
+});
 socket.on('visualize_infill', (data) => {
     vm.infill = data["infill"]
     console.log("infill rec " + vm.infill[0])

--- a/static/js/vue_instance.js
+++ b/static/js/vue_instance.js
@@ -17,6 +17,7 @@ const vm = new Vue({ // Again, vm is our Vue instance's name for consistency.
         connected: false,
         port: 'COM3',
         baud: '115200',
+        webhookUrl: '',
         ai_scores:{
             motivation_score: 0,
             complexity_score: 0,
@@ -417,6 +418,9 @@ const vm = new Vue({ // Again, vm is our Vue instance's name for consistency.
                 this.pauseLable = "Pause";
                 console.log("Printer resumed");
             }
+        },
+        exposeWebhook: function(event) {
+            socket.emit('expose_webhook');
         }
     },
 })

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,10 +38,14 @@
 					<button @click="print">[[ printLable ]]</button>
 					<button @click="pause">[[ pauseLable ]]</button>
 				</div>
-				<div id="test">
-					<p>We are on Layer:</p>
-					<input v-model="layer" placeholder="" disabled>
-				</div>
+                                <div id="test">
+                                        <p>We are on Layer:</p>
+                                        <input v-model="layer" placeholder="" disabled>
+                                </div>
+                                <div id="webhook">
+                                        <button @click="exposeWebhook">Expose Webhook</button>
+                                        <p v-if="webhookUrl">[[ webhookUrl ]]</p>
+                                </div>
 			</div>
 			<div id="options">
 				<div>


### PR DESCRIPTION
## Summary
- expose the Flask app via ngrok using a new Socket.IO event
- show the public webhook URL in the frontend when exposing
- allow the Vue client to request webhook exposure
- include `pyngrok` as a dependency

## Testing
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m pyngrok --version` *(fails: No module named pyngrok)*

------
https://chatgpt.com/codex/tasks/task_e_685033bb2768833294082fcb991b6f36